### PR TITLE
Add dev tools download link

### DIFF
--- a/bin/updateCheck.php
+++ b/bin/updateCheck.php
@@ -74,7 +74,8 @@ foreach( $versions as $k => $v )
             $posted = $v->longversion;
             $message  = "Version {$v->version}" . ( ( $k != 'dev' ) ? '' : " (Beta)" ) . " was just released";
             $message .= ( $v->security ) ? ' and is a security release!' : '.';
-            $message .= " View <https://invisioncommunity.com/release-notes/|Release Notes>";
+            $message .= " View <https://invisioncommunity.com/release-notes/|release notes>";
+            $message .= "/Download <https://remoteservices.invisionpower.com/devtools/{$v->longversion}|dev tools>";
             $message .= " _({$v->longversion})_";
 
             $slackClients['ipscontributors']->post( '#updates', $message, $attachments );


### PR DESCRIPTION
Changes the message from

> Version 4.5.3 was just released. View [Release Notes](#) _(105114)_

to

> Version 4.5.3 was just released. View [release notes](#)/Download [dev tools](#) _(105114)_